### PR TITLE
fix: admin mobile UX + attendee search

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -197,90 +197,168 @@ export default function AdminPage() {
             <span className='mx-auto block h-5 w-5 animate-spin rounded-full border-2 border-gray-300 border-t-black'></span>
           </div>
         ) : (
-          <div className='overflow-x-auto border border-default'>
-            <table className='w-full text-left text-sm'>
-              <thead className='bg-invert text-invert'>
-                <tr>
-                  <th className='px-4 py-2'>Name</th>
-                  <th className='px-4 py-2'>Email</th>
-                  <th className='px-4 py-2'>Crew</th>
-                  <th className='px-4 py-2'>Confirmed</th>
-                  <th className='px-4 py-2'>Status</th>
-                  <th className='px-4 py-2'>Action</th>
-                </tr>
-              </thead>
-              <tbody>
-                {attendees.map((a) => (
-                  <tr key={a.id} className='border-t border-default'>
-                    <td className='px-4 py-2'>
+          <>
+            {/* Mobile: card layout — no sideways scrolling */}
+            <div className='space-y-3 sm:hidden'>
+              {attendees.map((a) => (
+                <div key={a.id} className='border border-default p-4'>
+                  <div className='mb-2'>
+                    <p className='text-base'>
                       {a.first_name} {a.last_name}
-                    </td>
-                    <td className='px-4 py-2'>{a.email}</td>
-                    <td className='px-4 py-2'>{a.crew_name}</td>
-                    <td className='px-4 py-2'>
-                      <button
-                        onClick={() => handleToggleConfirmed(a.id, !a.confirmed)}
-                        disabled={toggling === a.id}
-                        title={
-                          a.confirmed
-                            ? 'Click to mark as not confirmed'
-                            : 'Click to mark as confirmed'
-                        }
-                        className={
-                          a.confirmed
-                            ? 'bg-green-600 p-[0.05rem] text-sm text-white hover:bg-green-700 disabled:opacity-50'
-                            : 'bg-amber-500 p-[0.05rem] text-sm text-white hover:bg-amber-600 disabled:opacity-50'
-                        }
-                      >
-                        {toggling === a.id
-                          ? '...'
-                          : a.confirmed
-                            ? 'Confirmed'
-                            : 'Not confirmed'}
-                      </button>
-                    </td>
-                    <td className='px-4 py-2'>
-                      {a.checked_in ? (
-                        <span className='bg-green-600 p-[0.05rem] text-sm text-white'>
-                          Checked in
-                        </span>
-                      ) : (
-                        <span className='text-gray-500'>Not checked in</span>
-                      )}
-                    </td>
-                    <td className='px-4 py-2'>
-                      {a.checked_in ? (
-                        <span className='text-xs text-gray-400'>
-                          {new Date(a.checked_in_at!).toLocaleString('de-DE', {
-                            day: '2-digit',
-                            month: '2-digit',
-                            hour: '2-digit',
-                            minute: '2-digit',
-                          })}
-                        </span>
-                      ) : (
+                    </p>
+                    <p className='break-all text-sm text-gray-500'>{a.email}</p>
+                    <p className='text-sm text-gray-500'>{a.crew_name}</p>
+                  </div>
+                  <div className='mb-3 flex flex-wrap items-center gap-2'>
+                    <button
+                      onClick={() => handleToggleConfirmed(a.id, !a.confirmed)}
+                      disabled={toggling === a.id}
+                      title={
+                        a.confirmed
+                          ? 'Click to mark as not confirmed'
+                          : 'Click to mark as confirmed'
+                      }
+                      className={
+                        a.confirmed
+                          ? 'bg-green-600 px-2 py-1 text-sm text-white hover:bg-green-700 disabled:opacity-50'
+                          : 'bg-amber-500 px-2 py-1 text-sm text-white hover:bg-amber-600 disabled:opacity-50'
+                      }
+                    >
+                      {toggling === a.id
+                        ? '...'
+                        : a.confirmed
+                          ? 'Confirmed'
+                          : 'Not confirmed'}
+                    </button>
+                    {a.checked_in ? (
+                      <span className='bg-green-600 px-2 py-1 text-sm text-white'>
+                        Checked in
+                      </span>
+                    ) : (
+                      <span className='text-sm text-gray-500'>
+                        Not checked in
+                      </span>
+                    )}
+                  </div>
+                  {a.checked_in ? (
+                    <p className='text-xs text-gray-400'>
+                      Checked in{' '}
+                      {new Date(a.checked_in_at!).toLocaleString('de-DE', {
+                        day: '2-digit',
+                        month: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </p>
+                  ) : (
+                    <button
+                      onClick={() => handleCheckIn(a.id)}
+                      disabled={checkingIn === a.id}
+                      className={
+                        a.confirmed
+                          ? 'w-full border-transparent bg-green-600 px-3 py-3 text-sm text-white hover:bg-green-700 disabled:opacity-50'
+                          : 'w-full border-transparent bg-amber-500 px-3 py-3 text-sm text-white hover:bg-amber-600 disabled:opacity-50'
+                      }
+                    >
+                      {checkingIn === a.id
+                        ? '...'
+                        : a.confirmed
+                          ? 'Check In'
+                          : 'Confirm & Check In'}
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+
+            {/* Desktop: table layout */}
+            <div className='hidden overflow-x-auto border border-default sm:block'>
+              <table className='w-full text-left text-sm'>
+                <thead className='bg-invert text-invert'>
+                  <tr>
+                    <th className='px-4 py-2'>Name</th>
+                    <th className='px-4 py-2'>Email</th>
+                    <th className='px-4 py-2'>Crew</th>
+                    <th className='px-4 py-2'>Confirmed</th>
+                    <th className='px-4 py-2'>Status</th>
+                    <th className='px-4 py-2'>Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {attendees.map((a) => (
+                    <tr key={a.id} className='border-t border-default'>
+                      <td className='px-4 py-2'>
+                        {a.first_name} {a.last_name}
+                      </td>
+                      <td className='px-4 py-2'>{a.email}</td>
+                      <td className='px-4 py-2'>{a.crew_name}</td>
+                      <td className='px-4 py-2'>
                         <button
-                          onClick={() => handleCheckIn(a.id)}
-                          disabled={checkingIn === a.id}
+                          onClick={() =>
+                            handleToggleConfirmed(a.id, !a.confirmed)
+                          }
+                          disabled={toggling === a.id}
+                          title={
+                            a.confirmed
+                              ? 'Click to mark as not confirmed'
+                              : 'Click to mark as confirmed'
+                          }
                           className={
                             a.confirmed
-                              ? 'border-transparent bg-green-600 px-3 py-1 text-xs text-white hover:bg-green-700 disabled:opacity-50'
-                              : 'border-transparent bg-amber-500 px-3 py-1 text-xs text-white hover:bg-amber-600 disabled:opacity-50'
+                              ? 'bg-green-600 p-[0.05rem] text-sm text-white hover:bg-green-700 disabled:opacity-50'
+                              : 'bg-amber-500 p-[0.05rem] text-sm text-white hover:bg-amber-600 disabled:opacity-50'
                           }
                         >
-                          {checkingIn === a.id
+                          {toggling === a.id
                             ? '...'
                             : a.confirmed
-                              ? 'Check In'
-                              : 'Confirm & Check In'}
+                              ? 'Confirmed'
+                              : 'Not confirmed'}
                         </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                      </td>
+                      <td className='px-4 py-2'>
+                        {a.checked_in ? (
+                          <span className='bg-green-600 p-[0.05rem] text-sm text-white'>
+                            Checked in
+                          </span>
+                        ) : (
+                          <span className='text-gray-500'>Not checked in</span>
+                        )}
+                      </td>
+                      <td className='px-4 py-2'>
+                        {a.checked_in ? (
+                          <span className='text-xs text-gray-400'>
+                            {new Date(a.checked_in_at!).toLocaleString('de-DE', {
+                              day: '2-digit',
+                              month: '2-digit',
+                              hour: '2-digit',
+                              minute: '2-digit',
+                            })}
+                          </span>
+                        ) : (
+                          <button
+                            onClick={() => handleCheckIn(a.id)}
+                            disabled={checkingIn === a.id}
+                            className={
+                              a.confirmed
+                                ? 'border-transparent bg-green-600 px-3 py-1 text-xs text-white hover:bg-green-700 disabled:opacity-50'
+                                : 'border-transparent bg-amber-500 px-3 py-1 text-xs text-white hover:bg-amber-600 disabled:opacity-50'
+                            }
+                          >
+                            {checkingIn === a.id
+                              ? '...'
+                              : a.confirmed
+                                ? 'Check In'
+                                : 'Confirm & Check In'}
+                          </button>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
 
         {totalPages > 1 && (

--- a/src/app/admin/stats/page.tsx
+++ b/src/app/admin/stats/page.tsx
@@ -90,7 +90,28 @@ export default function StatsPage() {
         )}
 
         <h2 className='mb-4 text-xl'>By Crew</h2>
-        <div className='overflow-hidden border border-default'>
+
+        {/* Mobile: card layout — no sideways scrolling */}
+        <div className='space-y-3 sm:hidden'>
+          {crews.map((c) => (
+            <div key={c.id} className='border border-default p-4'>
+              <p className='mb-2 text-base'>{c.name}</p>
+              <div className='flex justify-between text-sm'>
+                <span>Registered: {c.attendee_count}</span>
+                <span>Checked in: {c.checked_in_count}</span>
+                <span>
+                  {c.attendee_count > 0
+                    ? Math.round((c.checked_in_count / c.attendee_count) * 100)
+                    : 0}
+                  %
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Desktop: table layout */}
+        <div className='hidden overflow-hidden border border-default sm:block'>
           <table className='w-full text-left text-sm'>
             <thead className='bg-invert text-invert'>
               <tr>

--- a/src/app/api/admin/attendees/route.ts
+++ b/src/app/api/admin/attendees/route.ts
@@ -12,7 +12,7 @@ export async function GET(req: NextRequest) {
   }
 
   const { searchParams } = new URL(req.url)
-  const search = (searchParams.get('search') || '').slice(0, 100)
+  const search = (searchParams.get('search') || '').trim().slice(0, 100)
   const crewId = searchParams.get('crew_id')
   const checkedIn = searchParams.get('checked_in')
   const confirmed = searchParams.get('confirmed')
@@ -36,9 +36,18 @@ export async function GET(req: NextRequest) {
   )
 
   if (search) {
-    query = query.or(
-      `first_name.ilike.%${search}%,last_name.ilike.%${search}%,email.ilike.%${search}%`
-    )
+    // Match each word independently so "John", "John Smith" and "Smith John"
+    // all work: every word must match one of the name/email fields (AND across
+    // words, OR across fields). Chained .or() calls are combined with AND.
+    const terms = search
+      .split(/\s+/)
+      .map((t) => t.replace(/[%,()]/g, '').trim())
+      .filter(Boolean)
+    for (const term of terms) {
+      query = query.or(
+        `first_name.ilike.%${term}%,last_name.ilike.%${term}%,email.ilike.%${term}%`
+      )
+    }
   }
 
   if (crewId) {


### PR DESCRIPTION
## What & why

The check-in screen (`/admin`) had bad mobile UX — the 6-column table sat inside a horizontal-scroll container, so you had to scroll sideways to reach the **Check In** button. Search was also too strict.

## Changes

**Mobile layout** (`/admin`, `/admin/stats`)
- Below the `sm` breakpoint, attendees and crew stats render as stacked cards instead of a wide table. Action buttons are now full-width and reachable without sideways scrolling. Desktop keeps the original table.

**Attendee search** (`/api/admin/attendees`)
- Query is trimmed, so `"John "` no longer returns nothing.
- Multi-word matching: each word must match `first_name`, `last_name`, or `email` (AND across words, OR across fields). So `"John"`, `"John Smith"` and `"Smith John"` all work — matching how staff actually search at check-in.
- Strips PostgREST filter-significant characters from search terms.

## Test notes
- `npm run build` passes.
- Verify on a real phone / narrow viewport (< 640px) while logged in: `/admin` cards + full-width Check In button, `/admin/stats` crew cards, and search by first name / "first last".

🤖 Generated with [Claude Code](https://claude.com/claude-code)